### PR TITLE
Add support for SBC flipping by toggle option

### DIFF
--- a/mod/case_adapter.scad
+++ b/mod/case_adapter.scad
@@ -246,9 +246,11 @@ mb_adapters=[
                         (pcbhole_pos == "left_rear" || pcbhole_pos == "left_front" || pcbhole_pos == "right_rear" || pcbhole_pos == "right_front")) {
                         if (pcbhole_pos == "left_rear" && bottom_rear_left_enable == true) {
                             bottom_support = bottom_sidewall_support == true ? bottom_rear_left_support : "none";
+                            standoff_height = sbc_flip == false ? bottom_height-pcb_z+pcb_loc_z :
+                                bottom_height-pcb_bmaxz+pcb_tmaxz+pcb_loc_z;
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_rear_left_adjust,
+                                                standoff_height+bottom_rear_left_adjust,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -263,9 +265,11 @@ mb_adapters=[
                         }
                         if (pcbhole_pos == "left_front" && bottom_front_left_enable == true) {
                             bottom_support = bottom_sidewall_support == true ? bottom_front_left_support : "none";
+                            standoff_height = sbc_flip == false ? bottom_height-pcb_z+pcb_loc_z :
+                                bottom_height-pcb_bmaxz+pcb_tmaxz+pcb_loc_z;
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_front_left_adjust,
+                                                standoff_height+bottom_front_left_adjust,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -280,9 +284,11 @@ mb_adapters=[
                         }
                         if (pcbhole_pos == "right_rear" && bottom_rear_right_enable == true) {
                             bottom_support = bottom_sidewall_support == true ? bottom_rear_right_support : "none";
+                            standoff_height = sbc_flip == false ? bottom_height-pcb_z+pcb_loc_z :
+                                bottom_height-pcb_bmaxz+pcb_tmaxz+pcb_loc_z;
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_rear_right_adjust,
+                                                standoff_height+bottom_rear_right_adjust,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -297,9 +303,11 @@ mb_adapters=[
                         }
                         if (pcbhole_pos == "right_front" && bottom_front_right_enable == true) {
                             bottom_support = bottom_sidewall_support == true ? bottom_front_right_support : "none";
+                            standoff_height = sbc_flip == false ? bottom_height-pcb_z+pcb_loc_z :
+                                bottom_height-pcb_bmaxz+pcb_tmaxz+pcb_loc_z;
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_front_right_adjust,
+                                                standoff_height+bottom_front_right_adjust,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -381,8 +389,17 @@ module io_shield() {
             cube([io_window_x,4,io_window_z]);
         }
         translate([2,-2,2]) cube([io_window_x-4,5,io_window_z-4]);
-        translate([io_offset+pcb_loc_x,6+pcb_loc_y,bottom_height-pcb_z+pcb_loc_z+2]) 
-            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+        if(sbc_flip == false) {
+            translate([io_offset+pcb_loc_x,6+pcb_loc_y,bottom_height-pcb_z+pcb_loc_z+2]) 
+                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+        }
+        else {
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    translate([io_offset+pcb_loc_x + pcb_width/2, 6+pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z+2])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+        }
         // subtractive accessories
         if(accessory_name != "none") {
             for (i=[1:11:len(accessory_data[a[0]])-1]) {

--- a/mod/case_bottom.scad
+++ b/mod/case_bottom.scad
@@ -400,8 +400,11 @@ echo(pcb_depth+case_offset_y-10);
                         class = sbc_data[s[0]][i+1];
                         type = sbc_data[s[0]][i+2];
                         id = sbc_data[s[0]][i+3];
-                        pcbhole_x = sbc_data[s[0]][i+4]+pcb_loc_x;
-                        pcbhole_y = sbc_data[s[0]][i+5]+pcb_loc_y;
+                        // transform coordinates when flipped
+                        pcbhole_x = sbc_flip == false ? sbc_data[s[0]][i+4]+pcb_loc_x : 
+                            pcb_loc_x + pcb_width - sbc_data[s[0]][i+4];
+                        pcbhole_y = sbc_flip == false ? sbc_data[s[0]][i+5]+pcb_loc_y : 
+                            pcb_loc_y + pcb_depth - sbc_data[s[0]][i+5];
                         pcbhole_z = sbc_data[s[0]][i+6];
                         pcbhole_size = sbc_data[s[0]][i+9][0];
                         pcbhole_pos = sbc_data[s[0]][i+10][4];
@@ -615,20 +618,26 @@ echo(pcb_depth+case_offset_y-10);
                         class = sbc_data[s[0]][i+1];
                         type = sbc_data[s[0]][i+2];
                         id = sbc_data[s[0]][i+3];
-                        pcbhole_x = sbc_data[s[0]][i+4]+pcb_loc_x;
-                        pcbhole_y = sbc_data[s[0]][i+5]+pcb_loc_y;
+                        // transform coordinates when flipped
+                        pcbhole_x = sbc_flip == false ? sbc_data[s[0]][i+4]+pcb_loc_x : 
+                            pcb_loc_x + pcb_width - sbc_data[s[0]][i+4];
+                        pcbhole_y = sbc_flip == false ? sbc_data[s[0]][i+5]+pcb_loc_y : 
+                            pcb_loc_y + pcb_depth - sbc_data[s[0]][i+5];
                         pcbhole_z = sbc_data[s[0]][i+6];
                         pcbhole_size = sbc_data[s[0]][i+9][0];
                         pcbhole_pos = sbc_data[s[0]][i+10][4];
                         pcbadj_z = sbc_model == "n2" || sbc_model == "m1" ? -6 : 
                             sbc_model == "n2+" ? -4.5 : 0;
+                        // adjust standoff height for flipped sbc - PCB bottom (Z=0) with holes stays at Z=0, needs pcb_z to reach it
+                        standoff_height = sbc_flip == false ? bottom_height-pcb_z+pcb_loc_z : 
+                            bottom_height-pcb_bmaxz+pcb_tmaxz+pcb_loc_z;
 
                     if(class == "pcbhole" && id == pcb_id) {
                         if (pcbhole_pos == "left_rear" && bottom_rear_left_enable == true) {
                             bottom_support = bottom_sidewall_support == true ? bottom_rear_left_support : "none";
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_rear_left_adjust+pcbadj_z,
+                                                standoff_height+bottom_rear_left_adjust+pcbadj_z,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -650,7 +659,7 @@ echo(pcb_depth+case_offset_y-10);
                             bottom_support = bottom_sidewall_support == true ? bottom_front_left_support : "none";
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_front_left_adjust+pcbadj_z,
+                                                standoff_height+bottom_front_left_adjust+pcbadj_z,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -672,7 +681,7 @@ echo(pcb_depth+case_offset_y-10);
                             bottom_support = bottom_sidewall_support == true ? bottom_rear_right_support : "none";
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_rear_right_adjust+pcbadj_z,
+                                                standoff_height+bottom_rear_right_adjust+pcbadj_z,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -694,7 +703,7 @@ echo(pcb_depth+case_offset_y-10);
                             bottom_support = bottom_sidewall_support == true ? bottom_front_right_support : "none";
                             pcb_standoff = [bottom_standoff[0],
                                                 bottom_standoff[1],
-                                                bottom_height-pcb_z+pcb_loc_z+bottom_front_right_adjust+pcbadj_z,
+                                                standoff_height+bottom_front_right_adjust+pcbadj_z,
                                                 bottom_standoff[3],
                                                 bottom_standoff[4],
                                                 bottom_standoff[5],
@@ -729,12 +738,18 @@ echo(pcb_depth+case_offset_y-10);
                             pcbclass = sbc_data[s[0]][i+1];
                             pcbtype = sbc_data[s[0]][i+2];
                             id = sbc_data[s[0]][i+3];
-                            pcbhole_x = sbc_data[s[0]][i+4]+pcb_loc_x+pcbloc_x;
-                            pcbhole_y = sbc_data[s[0]][i+5]+pcb_loc_y+pcbloc_y;
+                            // transform coordinates when flipped
+                            pcbhole_x = sbc_flip == false ? sbc_data[s[0]][i+4]+pcb_loc_x+pcbloc_x : 
+                                pcb_loc_x + pcb_width - sbc_data[s[0]][i+4] - pcbloc_x;
+                            pcbhole_y = sbc_flip == false ? sbc_data[s[0]][i+5]+pcb_loc_y+pcbloc_y : 
+                                pcb_loc_y + pcb_depth - sbc_data[s[0]][i+5] - pcbloc_y;
                             pcbhole_z = sbc_data[s[0]][i+6];
                             pcbhole_size = sbc_data[s[0]][i+9][0];
                             pcbhole_state = sbc_data[s[0]][i+10][0];
                             pcbhole_pos = sbc_data[s[0]][i+10][4];
+                            // adjust standoff height for flipped sbc - PCB bottom (Z=0) with holes stays at Z=0, needs pcb_z to reach it
+                            multipcb_standoff_height = sbc_flip == false ? bottom_height-pcb_z+pcb_loc_z : 
+                                bottom_height-pcb_bmaxz+pcb_tmaxz+pcb_loc_z;
 
                             if(pcbclass == "pcbhole" && pcbid == id && id != 0) {
                                 if (pcbhole_pos == "left_rear" && multipcb_bottom_rear_left_enable == true && 
@@ -742,7 +757,7 @@ echo(pcb_depth+case_offset_y-10);
                                     bottom_support = multipcb_bottom_sidewall_support == true ? multipcb_bottom_rear_left_support : "none";
                                     pcb_standoff = [multipcb_bottom_standoff[0],
                                                         multipcb_bottom_standoff[1],
-                                                        bottom_height-pcb_z+pcb_loc_z+multipcb_bottom_rear_left_adjust,
+                                                        multipcb_standoff_height+multipcb_bottom_rear_left_adjust,
                                                         multipcb_bottom_standoff[3],
                                                         multipcb_bottom_standoff[4],
                                                         multipcb_bottom_standoff[5],
@@ -760,7 +775,7 @@ echo(pcb_depth+case_offset_y-10);
                                     bottom_support = multipcb_bottom_sidewall_support == true ? multipcb_bottom_front_left_support : "none";
                                     pcb_standoff = [multipcb_bottom_standoff[0],
                                                         multipcb_bottom_standoff[1],
-                                                        bottom_height-pcb_z+pcb_loc_z+multipcb_bottom_front_left_adjust,
+                                                        multipcb_standoff_height+multipcb_bottom_front_left_adjust,
                                                         multipcb_bottom_standoff[3],
                                                         multipcb_bottom_standoff[4],
                                                         multipcb_bottom_standoff[5],
@@ -778,7 +793,7 @@ echo(pcb_depth+case_offset_y-10);
                                     bottom_support = multipcb_bottom_sidewall_support == true ? multipcb_bottom_rear_right_support : "none";
                                     pcb_standoff = [multipcb_bottom_standoff[0],
                                                         multipcb_bottom_standoff[1],
-                                                        bottom_height-pcb_z+pcb_loc_z+multipcb_bottom_rear_right_adjust,
+                                                        multipcb_standoff_height+multipcb_bottom_rear_right_adjust,
                                                         multipcb_bottom_standoff[3],
                                                         multipcb_bottom_standoff[4],
                                                         multipcb_bottom_standoff[5],
@@ -796,7 +811,7 @@ echo(pcb_depth+case_offset_y-10);
                                     bottom_support = multipcb_bottom_sidewall_support == true ? multipcb_bottom_front_right_support : "none";
                                     pcb_standoff = [multipcb_bottom_standoff[0],
                                                         multipcb_bottom_standoff[1],
-                                                        bottom_height-pcb_z+pcb_loc_z+multipcb_bottom_front_right_adjust,
+                                                        multipcb_standoff_height+multipcb_bottom_front_right_adjust,
                                                         multipcb_bottom_standoff[3],
                                                         multipcb_bottom_standoff[4],
                                                         multipcb_bottom_standoff[5],
@@ -969,13 +984,30 @@ echo(pcb_depth+case_offset_y-10);
             }
         }
         // sbc openings
-        if(sbc_highlight == true) {
-            #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
-                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+        if(sbc_flip == false) {
+            if(sbc_highlight == true) {
+                #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
+                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            }
+            else {
+                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
+                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            }
         }
         else {
-            translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
-                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            // Flip SBC - match display geometry Z position exactly for proper alignment
+            if(sbc_highlight == true) {
+                    #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            }
+            else {
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            }
         }
         // indents
         if(indents == true) {

--- a/mod/case_side.scad
+++ b/mod/case_side.scad
@@ -568,34 +568,85 @@ module case_side(case_design, side) {
         }
         // sbc openings
         if(case_design != "panel_nas") {
-            if(sbc_highlight == true) {
-                #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj-adj]) 
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            if(sbc_flip == false) {
+                if(sbc_highlight == true) {
+                    #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj-adj]) 
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
+                else {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj-adj]) 
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
             }
             else {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj-adj]) 
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                // Flip SBC - match display geometry Z position exactly for proper alignment
+                if(sbc_highlight == true) {
+                    #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
+                else {
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
             }
         }
         else {
             if(nas_sbc_location == "top") {
-                if(sbc_highlight == true) {
-                    #translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                if(sbc_flip == false) {
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
                 else {
-                    translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
             }
             if(nas_sbc_location == "bottom") {
-                if(sbc_highlight == true) {
-                    #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                if(sbc_flip == false) {
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
                 else {
-                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
             }
         }

--- a/mod/case_top.scad
+++ b/mod/case_top.scad
@@ -880,34 +880,85 @@ module case_top(case_design) {
         }
         // sbc openings
         if(case_design != "panel_nas") {
-            if(sbc_highlight == true) {
-                #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+            if(sbc_flip == false) {
+                if(sbc_highlight == true) {
+                    #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
+                else {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
             }
             else {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj]) 
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                // Flip SBC - match display geometry Z position exactly for proper alignment
+                if(sbc_highlight == true) {
+                    #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
+                else {
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                }
             }
         }
         else {
             if(nas_sbc_location == "top") {
-                if(sbc_highlight == true) {
-                    #translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                if(sbc_flip == false) {
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
                 else {
-                    translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
             }
             if(nas_sbc_location == "bottom") {
-                if(sbc_highlight == true) {
-                    #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                if(sbc_flip == false) {
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
+                            sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
                 else {
-                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z]) 
-                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    if(sbc_highlight == true) {
+                        #translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
+                    else {
+                        translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_tmaxz+pcb_loc_z])
+                            rotate([180,0,180])
+                                translate([-pcb_width/2, -pcb_depth/2, 0])
+                                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, true);
+                    }
                 }
             }
         }

--- a/sbc_case_builder.scad
+++ b/sbc_case_builder.scad
@@ -35,6 +35,8 @@ sbc_model = "c1+"; //  ["c1+", "c2", "c4", "hc4", "c5", "xu4", "xu4q", "mc1", "h
 
 // sbc off in model view
 sbc_off = false;
+// flip sbc upside down (bottom side on top)
+sbc_flip = false;
 // sbc information display
 sbc_information = false;
 // enable highlight for sbc component subtractive geometry
@@ -752,8 +754,17 @@ if (view == "model") {
                 }
             }
             if(sbc_off == false) {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
         }
         if(case_design == "panel") {
@@ -776,8 +787,17 @@ if (view == "model") {
                 color("grey",1) translate([-move_leftside,0,0]) case_side(case_design,"left");
             }
             if(sbc_off == false) {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
         }
         if(case_design == "panel_nas") {
@@ -800,12 +820,30 @@ if (view == "model") {
                 color("dimgrey",1) translate([-move_leftside,0,0]) case_side(case_design,"left");
             }
             if(sbc_off == false && nas_sbc_location == "bottom") {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
             if(sbc_off == false && nas_sbc_location == "top") {
-                translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))+.5])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,case_z-(top_height+pcb_loc_z+(2*floorthick))+.5])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Rotate around center to keep SBC in same position, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, case_z-(top_height+pcb_loc_z+(2*floorthick))+.5 + (pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, -(pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
             for( i=[0:1:hd_bays-1]) {
                 if(hd_reverse == false) {
@@ -963,8 +1001,17 @@ if (view == "model") {
                 color("grey",1) translate([0,0,raise_top]) case_top(case_design);
             }
             if(sbc_off == false) {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
         }
         if(case_design == "tray" || case_design == "tray_sides" || case_design == "tray_vu5" || case_design == "tray_vu7") {
@@ -1055,8 +1102,17 @@ if (view == "model") {
                     case_z+27]) rotate([-15,0,180]) hk_speaker();
             }
             if(sbc_off == false) {
-                translate([pcb_loc_x,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Rotate around center to keep SBC in same position, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, bottom_height-pcb_z+pcb_loc_z-adj + (pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, -(pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
         } 
         if(case_design == "round" || case_design == "hex") {
@@ -1067,8 +1123,17 @@ if (view == "model") {
                 color("grey",1) translate([0,0,raise_top]) case_top(case_design);
             }        
             if(sbc_off == false) {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Rotate around center to keep SBC in same position, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, bottom_height-pcb_z+pcb_loc_z-adj + (pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, -(pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
         }
         if(case_design == "snap" || case_design == "fitted") {
@@ -1115,8 +1180,17 @@ if (view == "model") {
                 }
             }        
             if(sbc_off == false) {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-pcb_z+pcb_loc_z-adj])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Rotate around center to keep SBC in same position, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, bottom_height-pcb_z+pcb_loc_z-adj + (pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, -(pcb_z+pcb_tmaxz+pcb_bmaxz)/2])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
         }
         if(case_design == "rack") {
@@ -1241,8 +1315,17 @@ if (view == "model") {
         if(case_design == "adapter_mini-stx_thin" || case_design == "adapter_mini-stx" || case_design == "adapter_mini-itx_thin" || case_design == "adapter_mini-itx" || case_design == "adapter_flex-atx" || case_design == "adapter_mini-dtx" || case_design == "adapter_dtx" || case_design == "adapter_micro-atx" || case_design == "adapter_atx" || case_design == "adapter_ssi-ceb" || case_design == "adapter_ssi-eeb") {
             color("dimgrey",1) case_adapter(case_design);
             if(sbc_off == false) {
-                translate([pcb_loc_x ,pcb_loc_y,bottom_height-case_offset_bz-pcb_z+pcb_loc_z])
-                    sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                if(sbc_flip == false) {
+                    translate([pcb_loc_x ,pcb_loc_y,bottom_height-case_offset_bz-pcb_z+pcb_loc_z])
+                        sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
+                else {
+                    // Flip SBC - position PCB bottom at correct height, with 180° Z rotation to keep ports on same side
+                    translate([pcb_loc_x + pcb_width/2, pcb_loc_y + pcb_depth/2, floorthick+case_offset_bz+pcb_z+pcb_tmaxz+pcb_loc_z])
+                        rotate([180,0,180])
+                            translate([-pcb_width/2, -pcb_depth/2, 0])
+                                sbc(sbc_model, cooling, fan_size, gpio_opening, uart_opening, false);
+                }
             }
             if(case_design == "adapter_mini-stx_thin" || case_design == "adapter_mini-stx") {
                 color("dimgrey",1) translate([-1.2,-4.5,-2]) io_shield();


### PR DESCRIPTION
# Description
Added support for flipping SBC orientation in case builder, updates PCB hole positioning and standoff heights accordingly.

Use case: Having access to M.2 Ports on boards like Rock5B+

Note: Doesn't apply for rack option

# Images

Normal:
<img width="778" height="436" alt="SBC-Normal" src="https://github.com/user-attachments/assets/39de1896-f8d9-4667-927a-6c9c1767f713" />

Flipped:
<img width="778" height="438" alt="SBC-Flipped" src="https://github.com/user-attachments/assets/ee3d9de7-7966-49b7-adec-dcb170387c8e" />
